### PR TITLE
Bail out early when given an non-existing target function in the dispatch table

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,8 +21,8 @@ WriteMakefile(
     },
 
     BUILD_REQUIRES => {
-        'Test::More'      => 0.88, # done_testing()
-        'Test::Exception' => 0.32,
+        'Test::More'  => 0.88, # done_testing()
+        'Test::Fatal' => 0.014,
     },
     META_ADD => {
         'meta-spec' => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ WriteMakefile(
 
     BUILD_REQUIRES => {
         'Test::More'      => 0.88, # done_testing()
+        'Test::Exception' => 0.32,
     },
     META_ADD => {
         'meta-spec' => {

--- a/lib/Dancer/RPCPlugin/DispatchFromConfig.pm
+++ b/lib/Dancer/RPCPlugin/DispatchFromConfig.pm
@@ -30,7 +30,12 @@ sub dispatch_table_from_config {
         for my $rpc_method (@rpc_methods) {
             my $subname = $config->{$pkg}{$rpc_method};
             debug("[bdfc] $args->{endpoint}: $rpc_method => $subname");
-            $dispatch->{$rpc_method} = $pkg->can($subname);
+            if (my $handler = $pkg->can($subname)) {
+                $dispatch->{$rpc_method} = $handler;
+            }
+            else {
+                die "Handler not found for $rpc_method: $pkg\::$subname doesn't seem to exist.\n";
+            }
         }
     }
 

--- a/lib/Dancer/RPCPlugin/DispatchFromPod.pm
+++ b/lib/Dancer/RPCPlugin/DispatchFromPod.pm
@@ -70,7 +70,12 @@ sub _parse_file {
         my ($if_name, $code_name) = split " ", $ntoken->text;
         debug("[build_dispatcher] $args->{package}\::$code_name => $if_name");
 
-        $dispatch->{$if_name} = $args->{package}->can($code_name);
+        my $pkg = $args->{package};
+        if (my $handler = $pkg->can($code_name)) {
+            $dispatch->{$if_name} = $handler;
+        } else {
+            die "Handler not found for $if_name: $pkg\::$code_name doesn't seem to exist.\n";
+        }
     }
     return $dispatch;
 }

--- a/t/010-dispatch-from-config.t
+++ b/t/010-dispatch-from-config.t
@@ -3,12 +3,12 @@ use strict;
 use lib 't/lib';
 
 use Test::More;
+use Test::Exception;
 use Dancer::Test;
 
 use Dancer::RPCPlugin::DispatchFromConfig;
 
 {
-    pass("test");
     my $dispatch = dispatch_table_from_config(
         key      => 'xmlrpc',
         endpoint => '/xmlrpc',
@@ -28,6 +28,24 @@ use Dancer::RPCPlugin::DispatchFromConfig;
             'system.version' => \&TestProject::SystemCalls::do_version,
         },
         "Dispatch from YAML-config"
+    );
+
+    throws_ok(
+        sub {
+            dispatch_table_from_config(
+                key      => 'xmlrpc',
+                endpoint => '/xmlrpc',
+                config   => {
+                    '/xmlrpc' => {
+                        'TestProject::SystemCalls' => {
+                            'system.nonexistent' => 'nonexistent',
+                        }
+                    }
+                },
+            );
+        },
+        qr/Handler not found for system.nonexistent: TestProject::SystemCalls::nonexistent doesn't seem to exist/,
+        "Setting a non-existent dispatch target throws an exception"
     );
 }
 

--- a/t/010-dispatch-from-config.t
+++ b/t/010-dispatch-from-config.t
@@ -3,7 +3,7 @@ use strict;
 use lib 't/lib';
 
 use Test::More;
-use Test::Exception;
+use Test::Fatal;
 use Dancer::Test;
 
 use Dancer::RPCPlugin::DispatchFromConfig;
@@ -30,8 +30,8 @@ use Dancer::RPCPlugin::DispatchFromConfig;
         "Dispatch from YAML-config"
     );
 
-    throws_ok(
-        sub {
+    like(
+        exception {
             dispatch_table_from_config(
                 key      => 'xmlrpc',
                 endpoint => '/xmlrpc',

--- a/t/015-dispatch-from-pod.t
+++ b/t/015-dispatch-from-pod.t
@@ -3,7 +3,7 @@ use strict;
 use lib 't/lib';
 
 use Test::More;
-use Test::Exception;
+use Test::Fatal;
 use Dancer::Test;
 
 use Dancer::RPCPlugin::DispatchFromPod;
@@ -23,8 +23,8 @@ use Dancer::RPCPlugin::DispatchFromPod;
         "Dispatch table from POD"
     );
 
-    throws_ok(
-        sub {
+    like(
+        exception {
             dispatch_table_from_pod(
                 label    => 'jsonrpc',
                 packages => [qw/

--- a/t/015-dispatch-from-pod.t
+++ b/t/015-dispatch-from-pod.t
@@ -3,12 +3,12 @@ use strict;
 use lib 't/lib';
 
 use Test::More;
+use Test::Exception;
 use Dancer::Test;
 
 use Dancer::RPCPlugin::DispatchFromPod;
 
 {
-    pass("test");
     my $dispatch = dispatch_table_from_pod(
         label    => 'jsonrpc',
         packages => [qw/
@@ -21,6 +21,19 @@ use Dancer::RPCPlugin::DispatchFromPod;
             'api.uppercase' => \&TestProject::ApiCalls::do_uppercase,
         },
         "Dispatch table from POD"
+    );
+
+    throws_ok(
+        sub {
+            dispatch_table_from_pod(
+                label    => 'jsonrpc',
+                packages => [qw/
+                    TestProject::Bogus
+                /],
+            )
+        },
+        qr/Handler not found for bogus.nonexistent: TestProject::Bogus::nonexistent doesn't seem to exist/,
+        "Setting a non-existent dispatch target throws an exception"
     );
 }
 

--- a/t/lib/TestProject/Bogus.pm
+++ b/t/lib/TestProject/Bogus.pm
@@ -1,0 +1,20 @@
+package TestProject::Bogus;
+use warnings;
+use strict;
+
+=head2 nonexistent
+
+This function actually doesn't exist. It's only here to test that
+DispatchFromPod throws an error when given a nonexistent target function.
+
+=head3 XMLRPC bogus.nonexistent
+
+=for xmlrpc bogus.nonexistent nonexistent
+
+=head3 JSONRPC: bogus.nonexistent
+
+=for jsonrpc bogus.nonexistent nonexistent
+
+=cut
+
+1;


### PR DESCRIPTION
This prevents strange runtime errors ("use of uninitialized value on
subroutine entry") resulting from trying to call a non-function.
