### PR TITLE
Handle unhandled exceptions in callbacks

### DIFF
--- a/t/200-register-xmlrpc.t
+++ b/t/200-register-xmlrpc.t
@@ -130,6 +130,43 @@ my $p = RPC::XML::ParserFactory->new();
     );
 }
 
+{ # callback dies
+    xmlrpc '/endpoint_fail2' => {
+        publish => sub {
+            eval { require TestProject::SystemCalls; };
+            error("Cannot load: $@") if $@;
+            return {
+                'fail.ping' => dispatch_item(
+                    code => \&TestProject::SystemCalls::do_ping,
+                    package => 'TestProject::SystemCalls',
+                ),
+            };
+        },
+        callback => sub {
+            die "terrible death\n";
+        },
+    };
+
+    route_exists([POST => '/endpoint_fail2'], "/endpoint_fail2 registered");
+
+    my $response = dancer_response(
+        POST => '/endpoint_fail2',
+        {
+            headers => [
+                'Content-Type' => 'text/xml',
+            ],
+            body => RPC::XML::request->new('fail.ping')->as_string,
+        }
+    );
+
+    my $result = $p->parse($response->{content})->value;
+    is_deeply(
+        $result->value,
+        {faultCode => 500, faultString =>"terrible death\n"},
+        "fail.ping"
+    );
+}
+
 { # rpc-call fails
     xmlrpc '/endpoint_error' => {
         publish => sub {


### PR DESCRIPTION
Runtime exceptions in the 'callback' functions were not caught. Now we
handle them the same way as runtime exceptions in the actual methods.
